### PR TITLE
Implemented gitversioning

### DIFF
--- a/.github/workflows/package-nuget.yaml
+++ b/.github/workflows/package-nuget.yaml
@@ -12,6 +12,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Gitversion
+        uses: gittools/actions/gitversion/setup@v0
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0
 
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v3
@@ -20,16 +29,24 @@ jobs:
 
       - name: Build
         run: |
-          dotnet build --configuration Release
+          dotnet build `
+            --configuration Release `
+            /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }} `
+            /p:AssemblyFileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}
+        shell: pwsh
 
       - name: Pack
+        shell: pwsh
         run: |
-          dotnet pack .\src\My.Maui.Responsive\ --output .\output\ --configuration Release
+          dotnet pack .\src\My.Maui.Responsive\ `
+            --output .\output\ `
+            --configuration Release `
+            /p:Version=${{ steps.gitversion.outputs.fullSemVer }}
 
       - name: Upload to nuget
+        shell: pwsh
         run: |
           dotnet nuget push .\output\*.nupkg `
             --source https://api.nuget.org/v3/index.json `
-            --api-key ${{secrets.NUGET_API_KEY}} `
+            --api-key ${{ secrets.NUGET_API_KEY }} `
             --skip-duplicate
-        shell: pwsh

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,6 +14,15 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: dotnet test
-        run: dotnet test --configuration Release
+      - name: Build test projects
         shell: pwsh
+        run: |
+          dotnet build .\src\My.Maui.Responsive.Tests\ `
+            --configuration Release
+
+      - name: dotnet test
+        shell: pwsh
+        run: |
+          dotnet test `
+            --configuration Release `
+            --no-build


### PR DESCRIPTION
Updated package-nuget workflow to use GitVersion to derive Semver for packages.

fixes to run-test workflow to only build tests for better build performance.  Will only build .net8.0 framework for running the tests, brefore build was creating a build for android, ios and win10 which weren't used by the test project.